### PR TITLE
Align the text in tikz matrix

### DIFF
--- a/chap3_multitapeTM2.tex
+++ b/chap3_multitapeTM2.tex
@@ -49,7 +49,7 @@
 
 \begin{center}
 \begin{tikzpicture}[ampersand replacement=\&]
-\matrix[nodes={minimum height=8mm}] 
+\matrix[nodes={minimum height=8mm,text height=0.3cm}] 
 {
   \node[draw](0) {CPU}; \& [0.2cm] \& \& \node(1){} ; \& \&\&\& \&\&\& \&\&\& \\
 \& \node[draw]{\#};  \& \node[draw]{0}; \& \node[draw](a){$\dot{1}$}; \& \node[draw]{1}; \& \node[draw]{$\cdots$};


### PR DESCRIPTION
By setting text height in tikz node, the font with \dot can be aligned with those without \dot
Result of this commit:
Before:
![圖片](https://user-images.githubusercontent.com/15357227/99927907-ff2b7000-2d81-11eb-830f-87b0a207aa9e.png)

After:
![圖片](https://user-images.githubusercontent.com/15357227/99927863-d3a88580-2d81-11eb-8eed-67935f9d633f.png)
